### PR TITLE
change from ethercalc.org to ethercalc-cache.g0v.tw

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -127,7 +127,7 @@ block script
 
     // check where the csv will come from, ethercalc or gsheet?
     if(ethercalc_name.length < 40){
-      csv_api_source = 'https://ethercalc.org/_/'+ethercalc_name+'/csv';
+      csv_api_source = 'https://ethercalc-cache.g0v.tw/_/'+ethercalc_name+'/csv';
       csv_api_source_type = "ethercalc";
     }else{
       csv_api_source = 'docs.google.com/feeds/download/spreadsheets/Export?key='+ethercalc_name+'&exportFormat=csv&gid=0';


### PR DESCRIPTION
為了暫時解決因為 ethercalc 不穩而讓 hackfoldr 常常看不到內容的問題
我建置了 ethercalc-cache.g0v.tw ，一層可以擋在 ethercalc 前面的 proxy
程式放在 https://github.com/g0v/ethercalc-cache
相關說明在 https://g0v.hackmd.io/A175kRMVSxGqBRCerawXIA

請幫忙變更 hackfoldr，謝謝